### PR TITLE
feat: 회원가입과 로그인 구현

### DIFF
--- a/src/main/java/com/example/parking/api/member/MemberController.java
+++ b/src/main/java/com/example/parking/api/member/MemberController.java
@@ -3,22 +3,24 @@ package com.example.parking.api.member;
 import com.example.parking.application.member.MemberService;
 import com.example.parking.application.member.dto.MemberLoginRequest;
 import com.example.parking.application.member.dto.MemberSignupRequest;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpSession;
+import com.example.parking.auth.AuthService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+@RequiredArgsConstructor
 @RestController
 public class MemberController {
 
-    private final MemberService memberService;
+    private static final String JSESSIONID = "JSESSIONID";
 
-    public MemberController(MemberService memberService) {
-        this.memberService = memberService;
-    }
+    private final MemberService memberService;
+    private final AuthService authService;
 
     @PostMapping("/users")
     public ResponseEntity<Void> signup(@RequestBody MemberSignupRequest request) {
@@ -26,10 +28,13 @@ public class MemberController {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-    @PostMapping("login")
-    public ResponseEntity<Void> login(HttpServletRequest httpServletRequest, @RequestBody MemberLoginRequest request) {
-        HttpSession session = httpServletRequest.getSession();
+    @PostMapping("/login")
+    public ResponseEntity<Void> login(HttpServletResponse httpServletResponse,
+                                      @RequestBody MemberLoginRequest request) {
         Long memberId = memberService.login(request);
+        String sessionId = authService.createSession(memberId);
+        httpServletResponse.addCookie(new Cookie(JSESSIONID, sessionId));
+
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/src/main/java/com/example/parking/api/member/MemberController.java
+++ b/src/main/java/com/example/parking/api/member/MemberController.java
@@ -1,0 +1,35 @@
+package com.example.parking.api.member;
+
+import com.example.parking.application.member.MemberService;
+import com.example.parking.application.member.dto.MemberLoginRequest;
+import com.example.parking.application.member.dto.MemberSignupRequest;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class MemberController {
+
+    private final MemberService memberService;
+
+    public MemberController(MemberService memberService) {
+        this.memberService = memberService;
+    }
+
+    @PostMapping("/users")
+    public ResponseEntity<Void> signup(@RequestBody MemberSignupRequest request) {
+        memberService.signup(request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PostMapping("login")
+    public ResponseEntity<Void> login(HttpServletRequest httpServletRequest, @RequestBody MemberLoginRequest request) {
+        HttpSession session = httpServletRequest.getSession();
+        Long memberId = memberService.login(request);
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+}

--- a/src/main/java/com/example/parking/application/member/MemberService.java
+++ b/src/main/java/com/example/parking/application/member/MemberService.java
@@ -1,0 +1,58 @@
+package com.example.parking.application.member;
+
+import com.example.parking.application.member.dto.MemberLoginRequest;
+import com.example.parking.application.member.dto.MemberSignupRequest;
+import com.example.parking.application.member.exception.MemberLoginException;
+import com.example.parking.application.member.exception.MemberSignupException;
+import com.example.parking.domain.member.Member;
+import com.example.parking.domain.member.MemberRepository;
+import com.example.parking.domain.member.Password;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public MemberService(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+    @Transactional
+    public Long signup(MemberSignupRequest dto) {
+        Member member = new Member(
+                dto.getName(),
+                dto.getEmail(),
+                dto.getNickname(),
+                new Password(dto.getPassword()));
+
+        validateDuplicatedEmail(member);
+        memberRepository.save(member);
+        return member.getId();
+    }
+
+    private void validateDuplicatedEmail(Member member) {
+        if (memberRepository.existsByEmail(member.getEmail())) {
+            throw new MemberSignupException("중복된 이메일이라 회원가입이 불가능합니다.");
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public Long login(MemberLoginRequest dto) {
+        Member member = findMemberByEmail(dto.getEmail());
+        validatePassword(member, dto.getPassword());
+        return member.getId();
+    }
+
+    private Member findMemberByEmail(String email) {
+        return memberRepository.findByEmail(email)
+                .orElseThrow(() -> new MemberLoginException("회원가입되지 않은 유저아이디입니다."));
+    }
+
+    private void validatePassword(Member member, String password) {
+        if (!member.checkPassword(password)) {
+            throw new MemberLoginException("비밀번호가 틀립니다.");
+        }
+    }
+}

--- a/src/main/java/com/example/parking/application/member/dto/MemberLoginRequest.java
+++ b/src/main/java/com/example/parking/application/member/dto/MemberLoginRequest.java
@@ -1,0 +1,12 @@
+package com.example.parking.application.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberLoginRequest {
+
+    private String email;
+    private String password;
+}

--- a/src/main/java/com/example/parking/application/member/dto/MemberLoginRequest.java
+++ b/src/main/java/com/example/parking/application/member/dto/MemberLoginRequest.java
@@ -1,12 +1,17 @@
 package com.example.parking.application.member.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor
 public class MemberLoginRequest {
 
     private String email;
     private String password;
+
+    public MemberLoginRequest(String email, String password) {
+        this.email = email;
+        this.password = password;
+    }
 }

--- a/src/main/java/com/example/parking/application/member/dto/MemberSignupRequest.java
+++ b/src/main/java/com/example/parking/application/member/dto/MemberSignupRequest.java
@@ -1,0 +1,14 @@
+package com.example.parking.application.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberSignupRequest {
+
+    private String name;
+    private String email;
+    private String password;
+    private String nickname;
+}

--- a/src/main/java/com/example/parking/application/member/dto/MemberSignupRequest.java
+++ b/src/main/java/com/example/parking/application/member/dto/MemberSignupRequest.java
@@ -1,14 +1,21 @@
 package com.example.parking.application.member.dto;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@AllArgsConstructor
+@NoArgsConstructor
 public class MemberSignupRequest {
 
     private String name;
     private String email;
     private String password;
     private String nickname;
+
+    public MemberSignupRequest(String name, String email, String password, String nickname) {
+        this.name = name;
+        this.email = email;
+        this.password = password;
+        this.nickname = nickname;
+    }
 }

--- a/src/main/java/com/example/parking/application/member/exception/MemberLoginException.java
+++ b/src/main/java/com/example/parking/application/member/exception/MemberLoginException.java
@@ -1,0 +1,8 @@
+package com.example.parking.application.member.exception;
+
+public class MemberLoginException extends RuntimeException {
+
+    public MemberLoginException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/parking/application/member/exception/MemberSignupException.java
+++ b/src/main/java/com/example/parking/application/member/exception/MemberSignupException.java
@@ -1,0 +1,8 @@
+package com.example.parking.application.member.exception;
+
+public class MemberSignupException extends RuntimeException {
+
+    public MemberSignupException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/parking/auth/AuthService.java
+++ b/src/main/java/com/example/parking/auth/AuthService.java
@@ -25,7 +25,7 @@ public class AuthService {
 
     @Transactional(readOnly = true)
     public MemberSession findSession(String sessionId) {
-        return memberSessionRepository.findBySessionIdAndExpiredAtGreaterThanEqual(sessionId,
+        return memberSessionRepository.findBySessionIdAndExpiredAtIsGreaterThanEqual(sessionId,
                         LocalDateTime.now())
                 .orElseThrow(() -> new UnAuthorizationException("존재하지 않는 sessionId 입니다.", sessionId));
     }

--- a/src/main/java/com/example/parking/auth/AuthService.java
+++ b/src/main/java/com/example/parking/auth/AuthService.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
@@ -12,6 +13,7 @@ public class AuthService {
     private static final Long DURATION_MINUTE = 30L;
     private final MemberSessionRepository memberSessionRepository;
 
+    @Transactional
     public String createSession(Long memberId) {
         LocalDateTime current = LocalDateTime.now();
         String uuid = UUID.randomUUID().toString();

--- a/src/main/java/com/example/parking/auth/AuthService.java
+++ b/src/main/java/com/example/parking/auth/AuthService.java
@@ -22,4 +22,17 @@ public class AuthService {
         memberSessionRepository.save(memberSession);
         return memberSession.getSessionId();
     }
+
+    @Transactional(readOnly = true)
+    public MemberSession findSession(String sessionId) {
+        return memberSessionRepository.findBySessionIdAndExpiredAtGreaterThanEqual(sessionId,
+                        LocalDateTime.now())
+                .orElseThrow(() -> new UnAuthorizationException("존재하지 않는 sessionId 입니다.", sessionId));
+    }
+
+    @Transactional
+    public void updateSessionExpiredAt(MemberSession session) {
+        session.updateExpiredAt(LocalDateTime.now().plusMinutes(DURATION_MINUTE));
+        memberSessionRepository.save(session);
+    }
 }

--- a/src/main/java/com/example/parking/auth/AuthService.java
+++ b/src/main/java/com/example/parking/auth/AuthService.java
@@ -1,0 +1,23 @@
+package com.example.parking.auth;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class AuthService {
+
+    private static final Long DURATION_MINUTE = 30L;
+    private final MemberSessionRepository memberSessionRepository;
+
+    public String createSession(Long memberId) {
+        LocalDateTime current = LocalDateTime.now();
+        String uuid = UUID.randomUUID().toString();
+
+        MemberSession memberSession = new MemberSession(uuid, memberId, current, current.plusMinutes(DURATION_MINUTE));
+        memberSessionRepository.save(memberSession);
+        return memberSession.getSessionId();
+    }
+}

--- a/src/main/java/com/example/parking/auth/MemberSession.java
+++ b/src/main/java/com/example/parking/auth/MemberSession.java
@@ -1,0 +1,28 @@
+package com.example.parking.auth;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberSession {
+
+    @Id
+    private String sessionId;
+    private Long memberId;
+    private LocalDateTime createdAt;
+    private LocalDateTime expiredAt;
+
+    public MemberSession(String sessionId, Long memberId, LocalDateTime createdAt, LocalDateTime expiredAt) {
+        this.sessionId = sessionId;
+        this.memberId = memberId;
+        this.createdAt = createdAt;
+        this.expiredAt = expiredAt;
+    }
+}

--- a/src/main/java/com/example/parking/auth/MemberSession.java
+++ b/src/main/java/com/example/parking/auth/MemberSession.java
@@ -24,4 +24,8 @@ public class MemberSession {
         this.createdAt = createdAt;
         this.expiredAt = expiredAt;
     }
+
+    public void updateExpiredAt(LocalDateTime newExpiredAt) {
+        expiredAt = newExpiredAt;
+    }
 }

--- a/src/main/java/com/example/parking/auth/MemberSession.java
+++ b/src/main/java/com/example/parking/auth/MemberSession.java
@@ -2,11 +2,10 @@ package com.example.parking.auth;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Getter

--- a/src/main/java/com/example/parking/auth/MemberSessionRepository.java
+++ b/src/main/java/com/example/parking/auth/MemberSessionRepository.java
@@ -1,0 +1,6 @@
+package com.example.parking.auth;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberSessionRepository extends JpaRepository<MemberSession, String> {
+}

--- a/src/main/java/com/example/parking/auth/MemberSessionRepository.java
+++ b/src/main/java/com/example/parking/auth/MemberSessionRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberSessionRepository extends JpaRepository<MemberSession, String> {
 
-    Optional<MemberSession> findBySessionIdAndExpiredAtGreaterThanEqual(String sessionId, LocalDateTime expiredAt);
+    Optional<MemberSession> findBySessionIdAndExpiredAtIsGreaterThanEqual(String sessionId, LocalDateTime expiredAt);
 }

--- a/src/main/java/com/example/parking/auth/MemberSessionRepository.java
+++ b/src/main/java/com/example/parking/auth/MemberSessionRepository.java
@@ -1,6 +1,10 @@
 package com.example.parking.auth;
 
+import java.time.LocalDateTime;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberSessionRepository extends JpaRepository<MemberSession, String> {
+
+    Optional<MemberSession> findBySessionIdAndExpiredAtGreaterThanEqual(String sessionId, LocalDateTime expiredAt);
 }

--- a/src/main/java/com/example/parking/auth/UnAuthorizationException.java
+++ b/src/main/java/com/example/parking/auth/UnAuthorizationException.java
@@ -1,0 +1,15 @@
+package com.example.parking.auth;
+
+public class UnAuthorizationException extends RuntimeException {
+
+    private final String sessionId;
+
+    public UnAuthorizationException(String message, String sessionId) {
+        super(message);
+        this.sessionId = sessionId;
+    }
+
+    public String getSessionId() {
+        return sessionId;
+    }
+}

--- a/src/main/java/com/example/parking/config/WebMvcConfig.java
+++ b/src/main/java/com/example/parking/config/WebMvcConfig.java
@@ -1,0 +1,34 @@
+package com.example.parking.config;
+
+import com.example.parking.config.argumentresolver.AuthArgumentResolver;
+import com.example.parking.config.interceptor.AuthInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final AuthInterceptor authInterceptor;
+    private final AuthArgumentResolver authArgumentResolver;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(authInterceptor)
+                .addPathPatterns("/**")
+                .excludePathPatterns(List.of(
+                        "/users",
+                        "/login"
+                ));
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authArgumentResolver);
+    }
+}

--- a/src/main/java/com/example/parking/config/argumentresolver/AuthArgumentResolver.java
+++ b/src/main/java/com/example/parking/config/argumentresolver/AuthArgumentResolver.java
@@ -1,0 +1,32 @@
+package com.example.parking.config.argumentresolver;
+
+import com.example.parking.auth.AuthService;
+import com.example.parking.auth.MemberSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@RequiredArgsConstructor
+@Component
+public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private static final String JSESSIONID = "JSESSIONID";
+
+    private final AuthService authService;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(MemberAuth.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        String sessionId = webRequest.getHeader(JSESSIONID);
+        MemberSession session = authService.findSession(sessionId);
+        return session.getMemberId();
+    }
+}

--- a/src/main/java/com/example/parking/config/argumentresolver/MemberAuth.java
+++ b/src/main/java/com/example/parking/config/argumentresolver/MemberAuth.java
@@ -1,0 +1,11 @@
+package com.example.parking.config.argumentresolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MemberAuth {
+}

--- a/src/main/java/com/example/parking/config/interceptor/AuthInterceptor.java
+++ b/src/main/java/com/example/parking/config/interceptor/AuthInterceptor.java
@@ -1,0 +1,26 @@
+package com.example.parking.config.interceptor;
+
+import com.example.parking.auth.AuthService;
+import com.example.parking.auth.MemberSession;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@RequiredArgsConstructor
+@Component
+public class AuthInterceptor implements HandlerInterceptor {
+
+    private static final String JSESSIONID = "JSESSIONID";
+
+    private final AuthService authService;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        String sessionId = request.getHeader(JSESSIONID);
+        MemberSession session = authService.findSession(sessionId);
+        authService.updateSessionExpiredAt(session);
+        return true;
+    }
+}

--- a/src/main/java/com/example/parking/domain/member/Member.java
+++ b/src/main/java/com/example/parking/domain/member/Member.java
@@ -1,0 +1,57 @@
+package com.example.parking.domain.member;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Objects;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @Column(unique = true)
+    private String email;
+
+    private String nickname;
+
+    @Embedded
+    private Password password;
+
+    public Member(String name, String email, String nickname, Password password) {
+        this.name = name;
+        this.email = email;
+        this.nickname = nickname;
+        this.password = password;
+    }
+
+    public boolean checkPassword(String password) {
+        return this.password.isMatch(password);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Member member = (Member) o;
+        return Objects.equals(getId(), member.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId());
+    }
+}

--- a/src/main/java/com/example/parking/domain/member/MemberRepository.java
+++ b/src/main/java/com/example/parking/domain/member/MemberRepository.java
@@ -1,0 +1,12 @@
+package com.example.parking.domain.member;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    boolean existsByEmail(String email);
+
+    Optional<Member> findByEmail(String email);
+}

--- a/src/main/java/com/example/parking/domain/member/Password.java
+++ b/src/main/java/com/example/parking/domain/member/Password.java
@@ -1,0 +1,38 @@
+package com.example.parking.domain.member;
+
+import com.example.parking.util.cipher.SHA256;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Objects;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Password {
+
+    private String password;
+
+    public Password(String password) {
+        this.password = SHA256.encrypt(password);
+    }
+
+    public boolean isMatch(String password) {
+        return this.password.equals(SHA256.encrypt(password));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Password that = (Password) o;
+        return Objects.equals(password, that.password);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(password);
+    }
+}

--- a/src/main/java/com/example/parking/util/cipher/EncryptionException.java
+++ b/src/main/java/com/example/parking/util/cipher/EncryptionException.java
@@ -1,0 +1,8 @@
+package com.example.parking.util.cipher;
+
+public class EncryptionException extends RuntimeException {
+
+    public EncryptionException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/parking/util/cipher/SHA256.java
+++ b/src/main/java/com/example/parking/util/cipher/SHA256.java
@@ -1,0 +1,26 @@
+package com.example.parking.util.cipher;
+
+import java.security.MessageDigest;
+
+public class SHA256 {
+
+    private final static String ALG_NAME = "SHA-256";
+
+    public static String encrypt(String plainText) {
+        try {
+            MessageDigest md = MessageDigest.getInstance(ALG_NAME);
+            md.update(plainText.getBytes());
+            return bytesToHex(md.digest());
+        } catch (Exception e) {
+            throw new EncryptionException("암호화에 실패했습니다.");
+        }
+    }
+
+    private static String bytesToHex(byte[] bytes) {
+        StringBuilder builder = new StringBuilder();
+        for (byte b : bytes) {
+            builder.append(String.format("%02x", b));
+        }
+        return builder.toString();
+    }
+}

--- a/src/test/java/com/example/parking/auth/AuthServiceTest.java
+++ b/src/test/java/com/example/parking/auth/AuthServiceTest.java
@@ -1,0 +1,58 @@
+package com.example.parking.auth;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Transactional
+@SpringBootTest
+class AuthServiceTest {
+
+    @Autowired
+    private AuthService authService;
+
+    @Test
+    void 세션_아이디에_해당하는_세션을_찾는다() {
+        // given
+        Long memberId = 1L;
+        String sessionId = authService.createSession(memberId);
+
+        // when, then
+        assertThatNoException()
+                .isThrownBy(() -> authService.findSession(sessionId));
+    }
+
+    @Test
+    void 세션_아이디에_해당하는_세션이_존재하지_않으면_예외를_던진다() {
+        // given
+        String wrongSessionId = "아무세션아이디";
+
+        // when, then
+        assertThatThrownBy(() -> authService.findSession(wrongSessionId))
+                .isInstanceOf(UnAuthorizationException.class);
+    }
+
+    @Test
+    void 세션_만료시간을_갱신한다() {
+        // given
+        Long memberId = 1L;
+        String sessionId = authService.createSession(memberId);
+        MemberSession originSession = authService.findSession(sessionId);
+        LocalDateTime originExpiredAt = originSession.getExpiredAt();
+
+        // when
+        authService.updateSessionExpiredAt(originSession);
+        MemberSession updatedSession = authService.findSession(sessionId);
+        LocalDateTime updatedExpiredAt = updatedSession.getExpiredAt();
+
+        // then
+        assertThat(updatedExpiredAt).isAfter(originExpiredAt);
+    }
+}

--- a/src/test/java/com/example/parking/auth/MemberSessionRepositoryTest.java
+++ b/src/test/java/com/example/parking/auth/MemberSessionRepositoryTest.java
@@ -22,7 +22,7 @@ class MemberSessionRepositoryTest {
         memberSessionRepository.save(memberSession);
 
         // when, then
-        assertThat(memberSessionRepository.findBySessionIdAndExpiredAtGreaterThanEqual(memberSession.getSessionId(), LocalDateTime.now().minusDays(1)))
+        assertThat(memberSessionRepository.findBySessionIdAndExpiredAtIsGreaterThanEqual(memberSession.getSessionId(), LocalDateTime.now().minusDays(1)))
                 .isPresent();
     }
 
@@ -33,7 +33,7 @@ class MemberSessionRepositoryTest {
         memberSessionRepository.save(memberSession);
 
         // when, then
-        assertThat(memberSessionRepository.findBySessionIdAndExpiredAtGreaterThanEqual(memberSession.getSessionId(), LocalDateTime.now()))
+        assertThat(memberSessionRepository.findBySessionIdAndExpiredAtIsGreaterThanEqual(memberSession.getSessionId(), LocalDateTime.now()))
                 .isEmpty();
     }
 }

--- a/src/test/java/com/example/parking/auth/MemberSessionRepositoryTest.java
+++ b/src/test/java/com/example/parking/auth/MemberSessionRepositoryTest.java
@@ -1,0 +1,11 @@
+package com.example.parking.auth;
+
+import org.junit.jupiter.api.Test;
+
+class MemberSessionRepositoryTest {
+
+    @Test
+    void 현재_시간이_세션_만료_시간보다_늦으면_예외_발생() {
+
+    }
+}

--- a/src/test/java/com/example/parking/auth/MemberSessionRepositoryTest.java
+++ b/src/test/java/com/example/parking/auth/MemberSessionRepositoryTest.java
@@ -1,11 +1,39 @@
 package com.example.parking.auth;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
 class MemberSessionRepositoryTest {
 
-    @Test
-    void 현재_시간이_세션_만료_시간보다_늦으면_예외_발생() {
+    @Autowired
+    private MemberSessionRepository memberSessionRepository;
 
+    @Test
+    void 현재_시간이_세션_만료_시간보다_늦지_않으면_세션이_조회된다() {
+        // given
+        MemberSession memberSession = new MemberSession(UUID.randomUUID().toString(), 1L, LocalDateTime.now(), LocalDateTime.now());
+        memberSessionRepository.save(memberSession);
+
+        // when, then
+        assertThat(memberSessionRepository.findBySessionIdAndExpiredAtGreaterThanEqual(memberSession.getSessionId(), LocalDateTime.now().minusDays(1)))
+                .isPresent();
+    }
+
+    @Test
+    void 현재_시간이_세션_만료_시간보다_늦으면_빈_옵셔널을_반환한다() {
+        // given
+        MemberSession memberSession = new MemberSession(UUID.randomUUID().toString(), 1L, LocalDateTime.now(), LocalDateTime.now().minusDays(1));
+        memberSessionRepository.save(memberSession);
+
+        // when, then
+        assertThat(memberSessionRepository.findBySessionIdAndExpiredAtGreaterThanEqual(memberSession.getSessionId(), LocalDateTime.now()))
+                .isEmpty();
     }
 }


### PR DESCRIPTION
## 👍관련 이슈
- close: #11 

## 🤔세부 내용

회원가입과 로그인 구현

1. 회원가입
- 비밀번호 암호화 (SHA256)
- 이메일 인증은 더 얘기해봐야 될 것 같아 미구현 (플로우 문제)

2. 로그인
- 로그인 성공시 세션발급 (SET-COOKIE)
- 로그인 필요 API 접근시 (HTTP 헤더 중 JSESSIONID 사용)
- 다른 API 인증 인가에 필요한 인터셉터, 아규먼트리졸버 구현

## 🫵리뷰 중점사항
1. 세션 유지시간 초기화
사용자가 우리 서비스를 계속 이용할 시 (다른 API 호출이 이루어져 세션 확인을 진행할 때) 세션 만료시간을 계속 업데이트 하도록 했습니다.
서비스를 이용하다 로그인이 풀려버리면 안되기 때문입니다.

2. Garbage Session 정리
세션을 RDB안에 구현했는데, 사용자가 로그아웃을 누르는 빈도가 거의 없다고 생각됩니다.
그렇다면 만료된 세션을 디비상에서 지워줘야하는데 스케쥴러를 통해 지울까 싶습니다.
여러분들의 의견은 어떤가요?

3. 사용자 동시접속
현재는 사용자가 여러 기기에서 동시접속 할 수 있도록 구현했습니다.
동시접속에 대한 정책문제도 토의해야할듯 합니다.
동시접속을 불허하게 된다면 코드상의 변경점이 있을 것으로 보입니다.
