### PR TITLE
Feat/#15 주차 조건 설정 및 조회 기능 구현

### DIFF
--- a/src/main/java/com/example/parking/api/member/MemberController.java
+++ b/src/main/java/com/example/parking/api/member/MemberController.java
@@ -3,22 +3,24 @@ package com.example.parking.api.member;
 import com.example.parking.application.member.MemberService;
 import com.example.parking.application.member.dto.MemberLoginRequest;
 import com.example.parking.application.member.dto.MemberSignupRequest;
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpSession;
+import com.example.parking.auth.AuthService;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+@RequiredArgsConstructor
 @RestController
 public class MemberController {
 
-    private final MemberService memberService;
+    private static final String JSESSIONID = "JSESSIONID";
 
-    public MemberController(MemberService memberService) {
-        this.memberService = memberService;
-    }
+    private final MemberService memberService;
+    private final AuthService authService;
 
     @PostMapping("/users")
     public ResponseEntity<Void> signup(@RequestBody MemberSignupRequest request) {
@@ -26,10 +28,13 @@ public class MemberController {
         return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 
-    @PostMapping("login")
-    public ResponseEntity<Void> login(HttpServletRequest httpServletRequest, @RequestBody MemberLoginRequest request) {
-        HttpSession session = httpServletRequest.getSession();
+    @PostMapping("/login")
+    public ResponseEntity<Void> login(HttpServletResponse httpServletResponse,
+                                      @RequestBody MemberLoginRequest request) {
         Long memberId = memberService.login(request);
+        String sessionId = authService.createSession(memberId);
+        httpServletResponse.addCookie(new Cookie(JSESSIONID, sessionId));
+
         return ResponseEntity.status(HttpStatus.OK).build();
     }
 }

--- a/src/main/java/com/example/parking/api/member/MemberController.java
+++ b/src/main/java/com/example/parking/api/member/MemberController.java
@@ -1,0 +1,35 @@
+package com.example.parking.api.member;
+
+import com.example.parking.application.member.MemberService;
+import com.example.parking.application.member.dto.MemberLoginRequest;
+import com.example.parking.application.member.dto.MemberSignupRequest;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class MemberController {
+
+    private final MemberService memberService;
+
+    public MemberController(MemberService memberService) {
+        this.memberService = memberService;
+    }
+
+    @PostMapping("/users")
+    public ResponseEntity<Void> signup(@RequestBody MemberSignupRequest request) {
+        memberService.signup(request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+
+    @PostMapping("login")
+    public ResponseEntity<Void> login(HttpServletRequest httpServletRequest, @RequestBody MemberLoginRequest request) {
+        HttpSession session = httpServletRequest.getSession();
+        Long memberId = memberService.login(request);
+        return ResponseEntity.status(HttpStatus.OK).build();
+    }
+}

--- a/src/main/java/com/example/parking/api/searchcondition/SearchConditionController.java
+++ b/src/main/java/com/example/parking/api/searchcondition/SearchConditionController.java
@@ -1,0 +1,31 @@
+package com.example.parking.api.searchcondition;
+
+import com.example.parking.application.searchcondition.SearchConditionService;
+import com.example.parking.application.searchcondition.dto.SearchConditionDto;
+import com.example.parking.config.argumentresolver.MemberAuth;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class SearchConditionController {
+
+    private final SearchConditionService searchConditionService;
+
+    public SearchConditionController(SearchConditionService searchConditionService) {
+        this.searchConditionService = searchConditionService;
+    }
+
+    @GetMapping("/users/parkings/options")
+    public ResponseEntity<SearchConditionDto> loadSearchCondition(@MemberAuth Long memberId) {
+        return ResponseEntity.ok(searchConditionService.findSearchCondition(memberId));
+    }
+
+    @PutMapping("/users/parkings/options")
+    public ResponseEntity<Void> updateSearchCondition(@MemberAuth Long memberId, SearchConditionDto request) {
+        searchConditionService.updateSearchCondition(memberId, request);
+        return ResponseEntity.status(HttpStatus.CREATED).build();
+    }
+}

--- a/src/main/java/com/example/parking/application/member/MemberService.java
+++ b/src/main/java/com/example/parking/application/member/MemberService.java
@@ -1,0 +1,58 @@
+package com.example.parking.application.member;
+
+import com.example.parking.application.member.dto.MemberLoginRequest;
+import com.example.parking.application.member.dto.MemberSignupRequest;
+import com.example.parking.application.member.exception.MemberLoginException;
+import com.example.parking.application.member.exception.MemberSignupException;
+import com.example.parking.domain.member.Member;
+import com.example.parking.domain.member.MemberRepository;
+import com.example.parking.domain.member.Password;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public MemberService(MemberRepository memberRepository) {
+        this.memberRepository = memberRepository;
+    }
+
+    @Transactional
+    public Long signup(MemberSignupRequest dto) {
+        Member member = new Member(
+                dto.getName(),
+                dto.getEmail(),
+                dto.getNickname(),
+                new Password(dto.getPassword()));
+
+        validateDuplicatedEmail(member);
+        memberRepository.save(member);
+        return member.getId();
+    }
+
+    private void validateDuplicatedEmail(Member member) {
+        if (memberRepository.existsByEmail(member.getEmail())) {
+            throw new MemberSignupException("중복된 이메일이라 회원가입이 불가능합니다.");
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public Long login(MemberLoginRequest dto) {
+        Member member = findMemberByEmail(dto.getEmail());
+        validatePassword(member, dto.getPassword());
+        return member.getId();
+    }
+
+    private Member findMemberByEmail(String email) {
+        return memberRepository.findByEmail(email)
+                .orElseThrow(() -> new MemberLoginException("회원가입되지 않은 유저아이디입니다."));
+    }
+
+    private void validatePassword(Member member, String password) {
+        if (!member.checkPassword(password)) {
+            throw new MemberLoginException("비밀번호가 틀립니다.");
+        }
+    }
+}

--- a/src/main/java/com/example/parking/application/member/dto/MemberLoginRequest.java
+++ b/src/main/java/com/example/parking/application/member/dto/MemberLoginRequest.java
@@ -1,0 +1,12 @@
+package com.example.parking.application.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberLoginRequest {
+
+    private String email;
+    private String password;
+}

--- a/src/main/java/com/example/parking/application/member/dto/MemberSignupRequest.java
+++ b/src/main/java/com/example/parking/application/member/dto/MemberSignupRequest.java
@@ -1,0 +1,14 @@
+package com.example.parking.application.member.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MemberSignupRequest {
+
+    private String name;
+    private String email;
+    private String password;
+    private String nickname;
+}

--- a/src/main/java/com/example/parking/application/member/exception/MemberLoginException.java
+++ b/src/main/java/com/example/parking/application/member/exception/MemberLoginException.java
@@ -1,0 +1,8 @@
+package com.example.parking.application.member.exception;
+
+public class MemberLoginException extends RuntimeException {
+
+    public MemberLoginException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/parking/application/member/exception/MemberSignupException.java
+++ b/src/main/java/com/example/parking/application/member/exception/MemberSignupException.java
@@ -1,0 +1,8 @@
+package com.example.parking.application.member.exception;
+
+public class MemberSignupException extends RuntimeException {
+
+    public MemberSignupException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/parking/application/searchcondition/SearchConditionService.java
+++ b/src/main/java/com/example/parking/application/searchcondition/SearchConditionService.java
@@ -1,0 +1,78 @@
+package com.example.parking.application.searchcondition;
+
+import com.example.parking.application.searchcondition.dto.SearchConditionDto;
+import com.example.parking.domain.member.Member;
+import com.example.parking.domain.member.MemberRepository;
+import com.example.parking.domain.parking.OperationType;
+import com.example.parking.domain.parking.ParkingType;
+import com.example.parking.domain.parking.PayType;
+import com.example.parking.domain.searchcondition.SearchConditionAvailable;
+import com.example.parking.domain.searchcondition.FeeType;
+import com.example.parking.domain.searchcondition.Hours;
+import com.example.parking.domain.searchcondition.Priority;
+import com.example.parking.domain.searchcondition.SearchCondition;
+import com.example.parking.domain.searchcondition.SearchConditionRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Service
+public class SearchConditionService {
+
+    private final SearchConditionRepository searchConditionRepository;
+    private final MemberRepository memberRepository;
+
+    public SearchConditionDto findSearchCondition(Long memberId) {
+        SearchCondition searchCondition = searchConditionRepository.getByMemberId(memberId);
+        return toSearchConditionDto(searchCondition);
+    }
+
+    private SearchConditionDto toSearchConditionDto(SearchCondition searchCondition) {
+        return new SearchConditionDto(
+                toDescriptions(searchCondition.getOperationTypes()),
+                toDescriptions(searchCondition.getParkingTypes()),
+                toDescriptions(searchCondition.getFeeTypes()),
+                toDescriptions(searchCondition.getPayTypes()),
+                searchCondition.getPriority().getDescription(),
+                searchCondition.getHours().getHours()
+        );
+    }
+
+    private <E extends SearchConditionAvailable> List<String> toDescriptions(List<E> enums) {
+        return enums.stream()
+                .map(SearchConditionAvailable::getDescription)
+                .toList();
+    }
+
+    @Transactional
+    public void updateSearchCondition(Long memberId, SearchConditionDto searchConditionDto) {
+        SearchCondition newSearchCondition = createSearchCondition(memberId, searchConditionDto);
+
+        searchConditionRepository.findByMemberId(memberId).ifPresentOrElse(
+                existingSearchCondition -> existingSearchCondition.update(newSearchCondition),
+                () -> searchConditionRepository.save(newSearchCondition)
+        );
+    }
+
+    private SearchCondition createSearchCondition(Long memberId, SearchConditionDto searchConditionDto) {
+        Member member = memberRepository.getById(memberId);
+        return new SearchCondition(
+                member,
+                toEnums(searchConditionDto.getOperationType(), OperationType.values()),
+                toEnums(searchConditionDto.getParkingType(), ParkingType.values()),
+                toEnums(searchConditionDto.getFeeType(), FeeType.values()),
+                toEnums(searchConditionDto.getPayType(), PayType.values()),
+                SearchConditionAvailable.find(searchConditionDto.getPriority(), Priority.values()),
+                Hours.from(searchConditionDto.getHours())
+        );
+    }
+
+    public <E extends SearchConditionAvailable> List<E> toEnums(List<String> descriptions, E... values) {
+        return descriptions.stream()
+                .map(description -> SearchConditionAvailable.find(description, values))
+                .toList();
+    }
+}

--- a/src/main/java/com/example/parking/application/searchcondition/dto/SearchConditionDto.java
+++ b/src/main/java/com/example/parking/application/searchcondition/dto/SearchConditionDto.java
@@ -1,0 +1,25 @@
+package com.example.parking.application.searchcondition.dto;
+
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class SearchConditionDto {
+
+    private List<String> operationType;
+    private List<String> parkingType;
+    private List<String> feeType;
+    private List<String> payType;
+    private String priority;
+    private Integer hours;
+
+    public SearchConditionDto(List<String> operationType, List<String> parkingType, List<String> feeType,
+                              List<String> payType, String priority, Integer hours) {
+        this.operationType = operationType;
+        this.parkingType = parkingType;
+        this.feeType = feeType;
+        this.payType = payType;
+        this.priority = priority;
+        this.hours = hours;
+    }
+}

--- a/src/main/java/com/example/parking/auth/AuthService.java
+++ b/src/main/java/com/example/parking/auth/AuthService.java
@@ -25,7 +25,7 @@ public class AuthService {
 
     @Transactional(readOnly = true)
     public MemberSession findSession(String sessionId) {
-        return memberSessionRepository.findBySessionIdAndExpiredAtGreaterThanEqual(sessionId,
+        return memberSessionRepository.findBySessionIdAndExpiredAtIsGreaterThanEqual(sessionId,
                         LocalDateTime.now())
                 .orElseThrow(() -> new UnAuthorizationException("존재하지 않는 sessionId 입니다.", sessionId));
     }

--- a/src/main/java/com/example/parking/auth/AuthService.java
+++ b/src/main/java/com/example/parking/auth/AuthService.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
@@ -12,6 +13,7 @@ public class AuthService {
     private static final Long DURATION_MINUTE = 30L;
     private final MemberSessionRepository memberSessionRepository;
 
+    @Transactional
     public String createSession(Long memberId) {
         LocalDateTime current = LocalDateTime.now();
         String uuid = UUID.randomUUID().toString();

--- a/src/main/java/com/example/parking/auth/AuthService.java
+++ b/src/main/java/com/example/parking/auth/AuthService.java
@@ -22,4 +22,17 @@ public class AuthService {
         memberSessionRepository.save(memberSession);
         return memberSession.getSessionId();
     }
+
+    @Transactional(readOnly = true)
+    public MemberSession findSession(String sessionId) {
+        return memberSessionRepository.findBySessionIdAndExpiredAtGreaterThanEqual(sessionId,
+                        LocalDateTime.now())
+                .orElseThrow(() -> new UnAuthorizationException("존재하지 않는 sessionId 입니다.", sessionId));
+    }
+
+    @Transactional
+    public void updateSessionExpiredAt(MemberSession session) {
+        session.updateExpiredAt(LocalDateTime.now().plusMinutes(DURATION_MINUTE));
+        memberSessionRepository.save(session);
+    }
 }

--- a/src/main/java/com/example/parking/auth/AuthService.java
+++ b/src/main/java/com/example/parking/auth/AuthService.java
@@ -1,0 +1,23 @@
+package com.example.parking.auth;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class AuthService {
+
+    private static final Long DURATION_MINUTE = 30L;
+    private final MemberSessionRepository memberSessionRepository;
+
+    public String createSession(Long memberId) {
+        LocalDateTime current = LocalDateTime.now();
+        String uuid = UUID.randomUUID().toString();
+
+        MemberSession memberSession = new MemberSession(uuid, memberId, current, current.plusMinutes(DURATION_MINUTE));
+        memberSessionRepository.save(memberSession);
+        return memberSession.getSessionId();
+    }
+}

--- a/src/main/java/com/example/parking/auth/MemberSession.java
+++ b/src/main/java/com/example/parking/auth/MemberSession.java
@@ -1,0 +1,28 @@
+package com.example.parking.auth;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberSession {
+
+    @Id
+    private String sessionId;
+    private Long memberId;
+    private LocalDateTime createdAt;
+    private LocalDateTime expiredAt;
+
+    public MemberSession(String sessionId, Long memberId, LocalDateTime createdAt, LocalDateTime expiredAt) {
+        this.sessionId = sessionId;
+        this.memberId = memberId;
+        this.createdAt = createdAt;
+        this.expiredAt = expiredAt;
+    }
+}

--- a/src/main/java/com/example/parking/auth/MemberSession.java
+++ b/src/main/java/com/example/parking/auth/MemberSession.java
@@ -24,4 +24,8 @@ public class MemberSession {
         this.createdAt = createdAt;
         this.expiredAt = expiredAt;
     }
+
+    public void updateExpiredAt(LocalDateTime newExpiredAt) {
+        expiredAt = newExpiredAt;
+    }
 }

--- a/src/main/java/com/example/parking/auth/MemberSession.java
+++ b/src/main/java/com/example/parking/auth/MemberSession.java
@@ -2,11 +2,10 @@ package com.example.parking.auth;
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
+import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
 
 @Entity
 @Getter

--- a/src/main/java/com/example/parking/auth/MemberSessionRepository.java
+++ b/src/main/java/com/example/parking/auth/MemberSessionRepository.java
@@ -1,0 +1,6 @@
+package com.example.parking.auth;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberSessionRepository extends JpaRepository<MemberSession, String> {
+}

--- a/src/main/java/com/example/parking/auth/MemberSessionRepository.java
+++ b/src/main/java/com/example/parking/auth/MemberSessionRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberSessionRepository extends JpaRepository<MemberSession, String> {
 
-    Optional<MemberSession> findBySessionIdAndExpiredAtGreaterThanEqual(String sessionId, LocalDateTime expiredAt);
+    Optional<MemberSession> findBySessionIdAndExpiredAtIsGreaterThanEqual(String sessionId, LocalDateTime expiredAt);
 }

--- a/src/main/java/com/example/parking/auth/MemberSessionRepository.java
+++ b/src/main/java/com/example/parking/auth/MemberSessionRepository.java
@@ -1,6 +1,10 @@
 package com.example.parking.auth;
 
+import java.time.LocalDateTime;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemberSessionRepository extends JpaRepository<MemberSession, String> {
+
+    Optional<MemberSession> findBySessionIdAndExpiredAtGreaterThanEqual(String sessionId, LocalDateTime expiredAt);
 }

--- a/src/main/java/com/example/parking/auth/UnAuthorizationException.java
+++ b/src/main/java/com/example/parking/auth/UnAuthorizationException.java
@@ -1,0 +1,15 @@
+package com.example.parking.auth;
+
+public class UnAuthorizationException extends RuntimeException {
+
+    private final String sessionId;
+
+    public UnAuthorizationException(String message, String sessionId) {
+        super(message);
+        this.sessionId = sessionId;
+    }
+
+    public String getSessionId() {
+        return sessionId;
+    }
+}

--- a/src/main/java/com/example/parking/config/WebMvcConfig.java
+++ b/src/main/java/com/example/parking/config/WebMvcConfig.java
@@ -1,0 +1,34 @@
+package com.example.parking.config;
+
+import com.example.parking.config.argumentresolver.AuthArgumentResolver;
+import com.example.parking.config.interceptor.AuthInterceptor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Configuration
+public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final AuthInterceptor authInterceptor;
+    private final AuthArgumentResolver authArgumentResolver;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(authInterceptor)
+                .addPathPatterns("/**")
+                .excludePathPatterns(List.of(
+                        "/users",
+                        "/login"
+                ));
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authArgumentResolver);
+    }
+}

--- a/src/main/java/com/example/parking/config/argumentresolver/AuthArgumentResolver.java
+++ b/src/main/java/com/example/parking/config/argumentresolver/AuthArgumentResolver.java
@@ -1,0 +1,32 @@
+package com.example.parking.config.argumentresolver;
+
+import com.example.parking.auth.AuthService;
+import com.example.parking.auth.MemberSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@RequiredArgsConstructor
+@Component
+public class AuthArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private static final String JSESSIONID = "JSESSIONID";
+
+    private final AuthService authService;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(MemberAuth.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        String sessionId = webRequest.getHeader(JSESSIONID);
+        MemberSession session = authService.findSession(sessionId);
+        return session.getMemberId();
+    }
+}

--- a/src/main/java/com/example/parking/config/argumentresolver/MemberAuth.java
+++ b/src/main/java/com/example/parking/config/argumentresolver/MemberAuth.java
@@ -1,0 +1,11 @@
+package com.example.parking.config.argumentresolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MemberAuth {
+}

--- a/src/main/java/com/example/parking/config/interceptor/AuthInterceptor.java
+++ b/src/main/java/com/example/parking/config/interceptor/AuthInterceptor.java
@@ -1,0 +1,26 @@
+package com.example.parking.config.interceptor;
+
+import com.example.parking.auth.AuthService;
+import com.example.parking.auth.MemberSession;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@RequiredArgsConstructor
+@Component
+public class AuthInterceptor implements HandlerInterceptor {
+
+    private static final String JSESSIONID = "JSESSIONID";
+
+    private final AuthService authService;
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        String sessionId = request.getHeader(JSESSIONID);
+        MemberSession session = authService.findSession(sessionId);
+        authService.updateSessionExpiredAt(session);
+        return true;
+    }
+}

--- a/src/main/java/com/example/parking/domain/member/Member.java
+++ b/src/main/java/com/example/parking/domain/member/Member.java
@@ -1,0 +1,57 @@
+package com.example.parking.domain.member;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Objects;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    @Column(unique = true)
+    private String email;
+
+    private String nickname;
+
+    @Embedded
+    private Password password;
+
+    public Member(String name, String email, String nickname, Password password) {
+        this.name = name;
+        this.email = email;
+        this.nickname = nickname;
+        this.password = password;
+    }
+
+    public boolean checkPassword(String password) {
+        return this.password.isMatch(password);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Member member = (Member) o;
+        return Objects.equals(getId(), member.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId());
+    }
+}

--- a/src/main/java/com/example/parking/domain/member/MemberRepository.java
+++ b/src/main/java/com/example/parking/domain/member/MemberRepository.java
@@ -1,0 +1,12 @@
+package com.example.parking.domain.member;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+
+    boolean existsByEmail(String email);
+
+    Optional<Member> findByEmail(String email);
+}

--- a/src/main/java/com/example/parking/domain/member/MemberRepository.java
+++ b/src/main/java/com/example/parking/domain/member/MemberRepository.java
@@ -9,4 +9,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     boolean existsByEmail(String email);
 
     Optional<Member> findByEmail(String email);
+
+    default Member getById(Long id) {
+        return findById(id).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다."));
+    }
 }

--- a/src/main/java/com/example/parking/domain/member/Password.java
+++ b/src/main/java/com/example/parking/domain/member/Password.java
@@ -1,0 +1,38 @@
+package com.example.parking.domain.member;
+
+import com.example.parking.util.cipher.SHA256;
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.Objects;
+
+@Embeddable
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Password {
+
+    private String password;
+
+    public Password(String password) {
+        this.password = SHA256.encrypt(password);
+    }
+
+    public boolean isMatch(String password) {
+        return this.password.equals(SHA256.encrypt(password));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Password that = (Password) o;
+        return Objects.equals(password, that.password);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(password);
+    }
+}

--- a/src/main/java/com/example/parking/domain/parking/OperationType.java
+++ b/src/main/java/com/example/parking/domain/parking/OperationType.java
@@ -1,6 +1,10 @@
 package com.example.parking.domain.parking;
 
-public enum OperationType {
+import com.example.parking.domain.searchcondition.SearchConditionAvailable;
+import lombok.Getter;
+
+@Getter
+public enum OperationType implements SearchConditionAvailable {
 
     PUBLIC("공영"),
     PRIVATE("민영"),
@@ -10,5 +14,10 @@ public enum OperationType {
 
     OperationType(String description) {
         this.description = description;
+    }
+
+    @Override
+    public OperationType getDefault() {
+        return NO_INFO;
     }
 }

--- a/src/main/java/com/example/parking/domain/parking/ParkingType.java
+++ b/src/main/java/com/example/parking/domain/parking/ParkingType.java
@@ -1,5 +1,6 @@
 package com.example.parking.domain.parking;
 
+import com.example.parking.domain.searchcondition.SearchConditionAvailable;
 import java.util.Collections;
 import java.util.Map;
 import java.util.function.Function;
@@ -8,10 +9,10 @@ import java.util.stream.Stream;
 import lombok.Getter;
 
 @Getter
-public enum ParkingType {
-    OFF_STREET("노외 주차장"),
-    ON_STREET("노상 주차장"),
-    MECHANICAL("기계식 주차장"),
+public enum ParkingType implements SearchConditionAvailable {
+    OFF_STREET("노외"),
+    ON_STREET("노상"),
+    MECHANICAL("기계식"),
     NO_INFO("정보 없음");
 
     private static final Map<String, ParkingType> descriptions =
@@ -24,7 +25,9 @@ public enum ParkingType {
         this.description = description;
     }
 
-    public static ParkingType find(String description) {
-        return descriptions.getOrDefault(description, NO_INFO);
+    @Override
+    public ParkingType getDefault() {
+        return NO_INFO;
     }
 }
+

--- a/src/main/java/com/example/parking/domain/parking/PayType.java
+++ b/src/main/java/com/example/parking/domain/parking/PayType.java
@@ -1,19 +1,25 @@
 package com.example.parking.domain.parking;
 
+import com.example.parking.domain.searchcondition.SearchConditionAvailable;
 import lombok.Getter;
 
 @Getter
-public enum PayType {
+public enum PayType implements SearchConditionAvailable {
 
     CASH("현금"),
     CARD("카드"),
-    BANK_TRANSFER("계좌 이체"),
+    BANK_TRANSFER("계좌"),
     NO_INFO("정보 없음");
 
     private final String description;
 
     PayType(final String description) {
         this.description = description;
+    }
+
+    @Override
+    public PayType getDefault() {
+        return NO_INFO;
     }
 }
 

--- a/src/main/java/com/example/parking/domain/searchcondition/EnumListConverter.java
+++ b/src/main/java/com/example/parking/domain/searchcondition/EnumListConverter.java
@@ -1,0 +1,32 @@
+package com.example.parking.domain.searchcondition;
+
+import jakarta.persistence.AttributeConverter;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public abstract class EnumListConverter<E extends Enum<E>> implements AttributeConverter<List<E>, String> {
+
+    private static final String DELIMITER = ", ";
+
+    private final Class<E> enumClass;
+
+    protected EnumListConverter(Class<E> enumClass) {
+        this.enumClass = enumClass;
+    }
+
+    @Override
+    public String convertToDatabaseColumn(List<E> attribute) {
+        return attribute.stream()
+                .map(Enum::name)
+                .sorted()
+                .collect(Collectors.joining(DELIMITER));
+    }
+
+    @Override
+    public List<E> convertToEntityAttribute(String dbData) {
+        return Arrays.stream(dbData.split(DELIMITER))
+                .map(name -> Enum.valueOf(enumClass, name))
+                .toList();
+    }
+}

--- a/src/main/java/com/example/parking/domain/searchcondition/FeeType.java
+++ b/src/main/java/com/example/parking/domain/searchcondition/FeeType.java
@@ -1,0 +1,20 @@
+package com.example.parking.domain.searchcondition;
+
+import lombok.Getter;
+
+@Getter
+public enum FeeType implements SearchConditionAvailable {
+
+    FREE("무료"), PAID("유료"), NO_INFO("정보 없음");
+
+    private final String description;
+
+    FeeType(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public FeeType getDefault() {
+        return NO_INFO;
+    }
+}

--- a/src/main/java/com/example/parking/domain/searchcondition/FeeTypeConverter.java
+++ b/src/main/java/com/example/parking/domain/searchcondition/FeeTypeConverter.java
@@ -1,0 +1,11 @@
+package com.example.parking.domain.searchcondition;
+
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class FeeTypeConverter extends EnumListConverter<FeeType> {
+
+    public FeeTypeConverter() {
+        super(FeeType.class);
+    }
+}

--- a/src/main/java/com/example/parking/domain/searchcondition/Hours.java
+++ b/src/main/java/com/example/parking/domain/searchcondition/Hours.java
@@ -1,0 +1,25 @@
+package com.example.parking.domain.searchcondition;
+
+import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Embeddable
+public class Hours {
+
+    private int hours;
+
+    private Hours(int hours) {
+        this.hours = hours;
+    }
+
+    public static Hours from(int hours) {
+        if ((hours >= 1 && hours <= 12) || hours == 24) {
+            return new Hours(hours);
+        }
+        throw new IllegalArgumentException("이용 시간은 1~12, 24 시간까지만 선택할 수 있습니다.");
+    }
+}

--- a/src/main/java/com/example/parking/domain/searchcondition/OperationTypeConverter.java
+++ b/src/main/java/com/example/parking/domain/searchcondition/OperationTypeConverter.java
@@ -1,0 +1,12 @@
+package com.example.parking.domain.searchcondition;
+
+import com.example.parking.domain.parking.OperationType;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class OperationTypeConverter extends EnumListConverter<OperationType> {
+
+    public OperationTypeConverter() {
+        super(OperationType.class);
+    }
+}

--- a/src/main/java/com/example/parking/domain/searchcondition/ParkingTypeConverter.java
+++ b/src/main/java/com/example/parking/domain/searchcondition/ParkingTypeConverter.java
@@ -1,0 +1,12 @@
+package com.example.parking.domain.searchcondition;
+
+import com.example.parking.domain.parking.ParkingType;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class ParkingTypeConverter extends EnumListConverter<ParkingType> {
+
+    public ParkingTypeConverter() {
+        super(ParkingType.class);
+    }
+}

--- a/src/main/java/com/example/parking/domain/searchcondition/PayTypeConverter.java
+++ b/src/main/java/com/example/parking/domain/searchcondition/PayTypeConverter.java
@@ -1,0 +1,12 @@
+package com.example.parking.domain.searchcondition;
+
+import com.example.parking.domain.parking.PayType;
+import jakarta.persistence.Converter;
+
+@Converter(autoApply = true)
+public class PayTypeConverter extends EnumListConverter<PayType> {
+
+    public PayTypeConverter() {
+        super(PayType.class);
+    }
+}

--- a/src/main/java/com/example/parking/domain/searchcondition/Priority.java
+++ b/src/main/java/com/example/parking/domain/searchcondition/Priority.java
@@ -1,0 +1,22 @@
+package com.example.parking.domain.searchcondition;
+
+import lombok.Getter;
+
+@Getter
+public enum Priority implements SearchConditionAvailable {
+
+    DISTANCE("가까운순"),
+    PRICE("가격순"),
+    RECOMMENDATION("추천순");
+
+    private final String description;
+
+    Priority(String description) {
+        this.description = description;
+    }
+
+    @Override
+    public Priority getDefault() {
+        return RECOMMENDATION;
+    }
+}

--- a/src/main/java/com/example/parking/domain/searchcondition/SearchCondition.java
+++ b/src/main/java/com/example/parking/domain/searchcondition/SearchCondition.java
@@ -1,0 +1,65 @@
+package com.example.parking.domain.searchcondition;
+
+import com.example.parking.domain.member.Member;
+import com.example.parking.domain.parking.OperationType;
+import com.example.parking.domain.parking.ParkingType;
+import com.example.parking.domain.parking.PayType;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class SearchCondition {
+
+        @Id
+        @GeneratedValue(strategy = GenerationType.IDENTITY)
+        private Long id;
+
+        @OneToOne(fetch = FetchType.LAZY)
+        @JoinColumn
+        private Member member;
+
+        private List<OperationType> operationTypes;
+        private List<ParkingType> parkingTypes;
+        private List<FeeType> feeTypes;
+        private List<PayType> payTypes;
+
+        @Enumerated(EnumType.STRING)
+        private Priority priority;
+
+        @Embedded
+        private Hours hours;
+
+        public SearchCondition(Member member, List<OperationType> operationTypes, List<ParkingType> parkingTypes,
+                               List<FeeType> feeTypes, List<PayType> payTypes, Priority priority, Hours hours) {
+                this.member = member;
+                this.operationTypes = operationTypes;
+                this.parkingTypes = parkingTypes;
+                this.feeTypes = feeTypes;
+                this.payTypes = payTypes;
+                this.priority = priority;
+                this.hours = hours;
+        }
+
+        public void update(SearchCondition updated) {
+                this.operationTypes = updated.operationTypes;
+                this.parkingTypes = updated.parkingTypes;
+                this.feeTypes = updated.feeTypes;
+                this.payTypes = updated.payTypes;
+                this.priority = updated.priority;
+                this.hours = updated.hours;
+        }
+}

--- a/src/main/java/com/example/parking/domain/searchcondition/SearchConditionAvailable.java
+++ b/src/main/java/com/example/parking/domain/searchcondition/SearchConditionAvailable.java
@@ -1,0 +1,17 @@
+package com.example.parking.domain.searchcondition;
+
+import java.util.Arrays;
+
+public interface SearchConditionAvailable {
+
+    String getDescription();
+
+    <E extends SearchConditionAvailable> E getDefault();
+
+    static <E extends SearchConditionAvailable> E find(String description, E... values) {
+        return Arrays.stream(values)
+                .filter(e -> description.startsWith(e.getDescription()))
+                .findAny()
+                .orElse(values[0].getDefault());
+    }
+}

--- a/src/main/java/com/example/parking/domain/searchcondition/SearchConditionRepository.java
+++ b/src/main/java/com/example/parking/domain/searchcondition/SearchConditionRepository.java
@@ -1,0 +1,16 @@
+package com.example.parking.domain.searchcondition;
+
+import java.util.Optional;
+import org.springframework.data.repository.Repository;
+
+public interface SearchConditionRepository extends Repository<SearchCondition, Long> {
+
+    Optional<SearchCondition> findByMemberId(Long memberId);
+
+    default SearchCondition getByMemberId(Long memberId) {
+        return findByMemberId(memberId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 회원의 검색 조건이 존재하지 않습니다."));
+    }
+
+    void save(SearchCondition searchCondition);
+}

--- a/src/main/java/com/example/parking/util/cipher/EncryptionException.java
+++ b/src/main/java/com/example/parking/util/cipher/EncryptionException.java
@@ -1,0 +1,8 @@
+package com.example.parking.util.cipher;
+
+public class EncryptionException extends RuntimeException {
+
+    public EncryptionException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/parking/util/cipher/SHA256.java
+++ b/src/main/java/com/example/parking/util/cipher/SHA256.java
@@ -1,0 +1,26 @@
+package com.example.parking.util.cipher;
+
+import java.security.MessageDigest;
+
+public class SHA256 {
+
+    private final static String ALG_NAME = "SHA-256";
+
+    public static String encrypt(String plainText) {
+        try {
+            MessageDigest md = MessageDigest.getInstance(ALG_NAME);
+            md.update(plainText.getBytes());
+            return bytesToHex(md.digest());
+        } catch (Exception e) {
+            throw new EncryptionException("암호화에 실패했습니다.");
+        }
+    }
+
+    private static String bytesToHex(byte[] bytes) {
+        StringBuilder builder = new StringBuilder();
+        for (byte b : bytes) {
+            builder.append(String.format("%02x", b));
+        }
+        return builder.toString();
+    }
+}

--- a/src/test/java/com/example/parking/auth/AuthServiceTest.java
+++ b/src/test/java/com/example/parking/auth/AuthServiceTest.java
@@ -1,0 +1,58 @@
+package com.example.parking.auth;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Transactional
+@SpringBootTest
+class AuthServiceTest {
+
+    @Autowired
+    private AuthService authService;
+
+    @Test
+    void 세션_아이디에_해당하는_세션을_찾는다() {
+        // given
+        Long memberId = 1L;
+        String sessionId = authService.createSession(memberId);
+
+        // when, then
+        assertThatNoException()
+                .isThrownBy(() -> authService.findSession(sessionId));
+    }
+
+    @Test
+    void 세션_아이디에_해당하는_세션이_존재하지_않으면_예외를_던진다() {
+        // given
+        String wrongSessionId = "아무세션아이디";
+
+        // when, then
+        assertThatThrownBy(() -> authService.findSession(wrongSessionId))
+                .isInstanceOf(UnAuthorizationException.class);
+    }
+
+    @Test
+    void 세션_만료시간을_갱신한다() {
+        // given
+        Long memberId = 1L;
+        String sessionId = authService.createSession(memberId);
+        MemberSession originSession = authService.findSession(sessionId);
+        LocalDateTime originExpiredAt = originSession.getExpiredAt();
+
+        // when
+        authService.updateSessionExpiredAt(originSession);
+        MemberSession updatedSession = authService.findSession(sessionId);
+        LocalDateTime updatedExpiredAt = updatedSession.getExpiredAt();
+
+        // then
+        assertThat(updatedExpiredAt).isAfter(originExpiredAt);
+    }
+}

--- a/src/test/java/com/example/parking/auth/MemberSessionRepositoryTest.java
+++ b/src/test/java/com/example/parking/auth/MemberSessionRepositoryTest.java
@@ -22,7 +22,7 @@ class MemberSessionRepositoryTest {
         memberSessionRepository.save(memberSession);
 
         // when, then
-        assertThat(memberSessionRepository.findBySessionIdAndExpiredAtGreaterThanEqual(memberSession.getSessionId(), LocalDateTime.now().minusDays(1)))
+        assertThat(memberSessionRepository.findBySessionIdAndExpiredAtIsGreaterThanEqual(memberSession.getSessionId(), LocalDateTime.now().minusDays(1)))
                 .isPresent();
     }
 
@@ -33,7 +33,7 @@ class MemberSessionRepositoryTest {
         memberSessionRepository.save(memberSession);
 
         // when, then
-        assertThat(memberSessionRepository.findBySessionIdAndExpiredAtGreaterThanEqual(memberSession.getSessionId(), LocalDateTime.now()))
+        assertThat(memberSessionRepository.findBySessionIdAndExpiredAtIsGreaterThanEqual(memberSession.getSessionId(), LocalDateTime.now()))
                 .isEmpty();
     }
 }

--- a/src/test/java/com/example/parking/auth/MemberSessionRepositoryTest.java
+++ b/src/test/java/com/example/parking/auth/MemberSessionRepositoryTest.java
@@ -1,0 +1,11 @@
+package com.example.parking.auth;
+
+import org.junit.jupiter.api.Test;
+
+class MemberSessionRepositoryTest {
+
+    @Test
+    void 현재_시간이_세션_만료_시간보다_늦으면_예외_발생() {
+
+    }
+}

--- a/src/test/java/com/example/parking/auth/MemberSessionRepositoryTest.java
+++ b/src/test/java/com/example/parking/auth/MemberSessionRepositoryTest.java
@@ -1,11 +1,39 @@
 package com.example.parking.auth;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
 class MemberSessionRepositoryTest {
 
-    @Test
-    void 현재_시간이_세션_만료_시간보다_늦으면_예외_발생() {
+    @Autowired
+    private MemberSessionRepository memberSessionRepository;
 
+    @Test
+    void 현재_시간이_세션_만료_시간보다_늦지_않으면_세션이_조회된다() {
+        // given
+        MemberSession memberSession = new MemberSession(UUID.randomUUID().toString(), 1L, LocalDateTime.now(), LocalDateTime.now());
+        memberSessionRepository.save(memberSession);
+
+        // when, then
+        assertThat(memberSessionRepository.findBySessionIdAndExpiredAtGreaterThanEqual(memberSession.getSessionId(), LocalDateTime.now().minusDays(1)))
+                .isPresent();
+    }
+
+    @Test
+    void 현재_시간이_세션_만료_시간보다_늦으면_빈_옵셔널을_반환한다() {
+        // given
+        MemberSession memberSession = new MemberSession(UUID.randomUUID().toString(), 1L, LocalDateTime.now(), LocalDateTime.now().minusDays(1));
+        memberSessionRepository.save(memberSession);
+
+        // when, then
+        assertThat(memberSessionRepository.findBySessionIdAndExpiredAtGreaterThanEqual(memberSession.getSessionId(), LocalDateTime.now()))
+                .isEmpty();
     }
 }

--- a/src/test/java/com/example/parking/domain/searchcondition/EnumListConverterTest.java
+++ b/src/test/java/com/example/parking/domain/searchcondition/EnumListConverterTest.java
@@ -1,0 +1,29 @@
+package com.example.parking.domain.searchcondition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class EnumListConverterTest {
+
+    @DisplayName("DB에 Enum을 List형식으로 저장할 때, Enum의 값 이름과 " + '"' + ", " + '"'+ " 구분자를 이용해서 저장된다.")
+    @Test
+    void convertTest() {
+        //given
+        FeeTypeConverter feeTypeConverter = new FeeTypeConverter();
+        List<FeeType> expectedFeeType = List.of(FeeType.FREE, FeeType.PAID);
+        String expectedDatabaseColumn = expectedFeeType.stream().map(FeeType::name)
+                .collect(Collectors.joining(", "));
+
+        //when
+        String actualDatabaseField = feeTypeConverter.convertToDatabaseColumn(expectedFeeType);
+        List<FeeType> actualFeeTypes = feeTypeConverter.convertToEntityAttribute(actualDatabaseField);
+
+        //then
+        assertThat(actualDatabaseField).isEqualTo(expectedDatabaseColumn);
+        assertThat(actualFeeTypes).isEqualTo(expectedFeeType);
+    }
+}

--- a/src/test/java/com/example/parking/domain/searchcondition/HoursTest.java
+++ b/src/test/java/com/example/parking/domain/searchcondition/HoursTest.java
@@ -1,0 +1,22 @@
+package com.example.parking.domain.searchcondition;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+class HoursTest {
+
+    @CsvSource({"1, false", "12, false", "24, false", "0, true", "13, true"})
+    @ParameterizedTest
+    void 이용_시간은_1시간에서_12시간_사이_또는_24시간만_선택_가능하다(int hours, boolean hasException) {
+        //given, when, then
+        if (hasException) {
+            Assertions.assertThatThrownBy(() -> Hours.from(hours))
+                    .isInstanceOf(IllegalArgumentException.class);
+            return;
+        }
+        assertDoesNotThrow(() -> Hours.from(hours));
+    }
+}

--- a/src/test/java/com/example/parking/domain/searchcondition/SearchConditionAvailableTest.java
+++ b/src/test/java/com/example/parking/domain/searchcondition/SearchConditionAvailableTest.java
@@ -1,0 +1,41 @@
+package com.example.parking.domain.searchcondition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import com.example.parking.domain.parking.OperationType;
+import com.example.parking.domain.parking.ParkingType;
+import com.example.parking.domain.parking.PayType;
+import java.util.stream.Stream;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class SearchConditionAvailableTest {
+
+    @ParameterizedTest
+    @MethodSource("parametersProvider")
+    <E extends SearchConditionAvailable> void 설명과_enum_values_로_해당하는_값을_찾고_없으면_default를_반환한다(String description,
+                                                                                             E expected, E... values) {
+        //given, when
+        E actual = SearchConditionAvailable.find(description, values);
+
+        //then
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    static Stream<Arguments> parametersProvider() {
+        return Stream.of(
+                arguments("민영 주차장", OperationType.PRIVATE, OperationType.values()),
+                arguments("공영", OperationType.PUBLIC, OperationType.values()),
+                arguments("노상", ParkingType.ON_STREET, ParkingType.values()),
+                arguments("노외 주차장", ParkingType.OFF_STREET, ParkingType.values()),
+                arguments("무료", FeeType.FREE, FeeType.values()),
+                arguments("유료", FeeType.PAID, FeeType.values()),
+                arguments("계좌", PayType.BANK_TRANSFER, PayType.values()),
+                arguments("~", PayType.NO_INFO, PayType.values()),
+                arguments("가격순", Priority.PRICE, Priority.values()),
+                arguments("아무거나 입력", Priority.RECOMMENDATION, Priority.values())
+        );
+    }
+}


### PR DESCRIPTION
## 👍관련 이슈
- close: #15 

## 🤔세부 내용
- 주차 조건 설정 및 조회 스펙이 변경되어서 하나의 조건도 여러가지 저장할 수 있어야하는데 이를 List<Enum> 저장시 ", " 구분자로 구분해서 하나의 필드로 저장하게 구현했습니다.
- Enum <-> DTO 변환간에 중복이 많아서 `SearchConditionAvailable` 라는 인터페이스 만들어서 해결했는데, 좋은 방법 있으면 추천 부탁드립니다.

## 🫵리뷰 중점사항
- 회원이 필요해서 하디 브랜치에서 시작했는데, 커밋이 같이 합쳐지네여 [작업 커밋](https://github.com/parkingkim/parking-BE/pull/16/files/da37fced22e8a43dc28009b6cd78e63eef0222a1..eaa5e738ab9864732423425ecd9c02a82ec64036) 이거 보면 될듯여
