### PR TITLE
스케줄링 주차장 정보 수정 트랜잭션 분리

### DIFF
--- a/app-scheduler/src/main/java/com/parkingcomestrue/external/service/ParkingService.java
+++ b/app-scheduler/src/main/java/com/parkingcomestrue/external/service/ParkingService.java
@@ -1,0 +1,36 @@
+package com.parkingcomestrue.external.service;
+
+
+import com.parkingcomestrue.common.domain.parking.Parking;
+import com.parkingcomestrue.common.domain.parking.repository.ParkingRepository;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class ParkingService {
+
+    private final ParkingRepository parkingRepository;
+
+    @Transactional
+    public void updateParkingLots(Map<String, Parking> parkingLots, Map<String, Parking> saved,
+                                  List<Parking> newParkingLots) {
+        updateSavedParkingLots(parkingLots, saved);
+        saveNewParkingLots(newParkingLots);
+    }
+
+    private void updateSavedParkingLots(Map<String, Parking> parkingLots, Map<String, Parking> saved) {
+        for (String parkingName : saved.keySet()) {
+            Parking origin = saved.get(parkingName);
+            Parking updated = parkingLots.get(parkingName);
+            origin.update(updated);
+        }
+    }
+
+    private void saveNewParkingLots(List<Parking> newParkingLots) {
+        parkingRepository.saveAll(newParkingLots);
+    }
+}

--- a/app-scheduler/src/test/java/com/parkingcomestrue/external/scheduler/ParkingUpdateSchedulerTest.java
+++ b/app-scheduler/src/test/java/com/parkingcomestrue/external/scheduler/ParkingUpdateSchedulerTest.java
@@ -2,6 +2,8 @@ package com.parkingcomestrue.external.scheduler;
 
 
 import com.parkingcomestrue.external.coordinate.CoordinateApiService;
+import com.parkingcomestrue.external.domain.parking.repository.ParkingRepository;
+import com.parkingcomestrue.external.service.ParkingService;
 import com.parkingcomestrue.fake.ExceptionParkingApiService;
 import com.parkingcomestrue.fake.FakeCoordinateApiService;
 import com.parkingcomestrue.fake.NotOfferCurrentParkingApiService;
@@ -29,7 +31,8 @@ class ParkingUpdateSchedulerTest {
         ParkingUpdateScheduler scheduler = new ParkingUpdateScheduler(
                 List.of(offerCurrentParkingApiService),
                 coordinateService,
-                parkingRepository
+                (ParkingRepository) parkingRepository,
+                new ParkingService((ParkingRepository) parkingRepository)
         );
 
         //when
@@ -52,7 +55,8 @@ class ParkingUpdateSchedulerTest {
         ParkingUpdateScheduler scheduler = new ParkingUpdateScheduler(
                 List.of(notOfferCurrentParkingApiService),
                 coordinateService,
-                parkingRepository
+                (ParkingRepository) parkingRepository,
+                new ParkingService((ParkingRepository) parkingRepository)
         );
 
         //when
@@ -76,7 +80,8 @@ class ParkingUpdateSchedulerTest {
         ParkingUpdateScheduler scheduler = new ParkingUpdateScheduler(
                 List.of(offerCurrentParkingApiService, notOfferCurrentParkingApiService),
                 coordinateService,
-                parkingRepository
+                (ParkingRepository) parkingRepository,
+                new ParkingService((ParkingRepository) parkingRepository)
         );
 
         //when
@@ -93,7 +98,8 @@ class ParkingUpdateSchedulerTest {
         ParkingUpdateScheduler scheduler = new ParkingUpdateScheduler(
                 List.of(new OfferCurrentParkingApiService(5), new ExceptionParkingApiService()),
                 coordinateService,
-                parkingRepository
+                (ParkingRepository) parkingRepository,
+                new ParkingService((ParkingRepository) parkingRepository)
         );
 
         //when


### PR DESCRIPTION
## 🤔세부 내용
- 스케줄링 돌면서 외부 api 로 조회한 주차장 정보 갱신 시 하나의 커넥션으로 처리할 수 있게 트랜잭션 추가했습니다.
- 트랜잭션 범위에서 외부 api 호출을 분리하기 위해 ParkingService 란 객체 추가했습니다. (네이밍은 마땅한게 생각이 안나네요)
    - Scheduler -> ParkingService
